### PR TITLE
Handle missing UVR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 ## Ultimate Chord Reader
 
 The `ultimate_chord_reader.py` script provides a local workflow for transcribing songs. Drop audio files into `input_songs/` and run `python ultimate_chord_reader.py` to generate text chord charts in `output_charts/`.
+
+### Optional: Ultimate Vocal Remover
+
+By default the separation step uses both [Demucs](https://github.com/facebookresearch/demucs) and Ultimate Vocal Remover (UVR). If `uvr.py` is not available on your system, the script will automatically fall back to using Demucs only. To enable UVR support, clone the UVR repository and ensure the `uvr.py` entry point is on your `PATH`.

--- a/models/mvsep_loader.py
+++ b/models/mvsep_loader.py
@@ -5,6 +5,7 @@ Assumes `uvr.py` is installed and available on the system path.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Tuple
@@ -15,9 +16,16 @@ def run_uvr(input_path: str, output_dir: str) -> Tuple[Path, Path]:
     output = Path(output_dir)
     output.mkdir(parents=True, exist_ok=True)
 
+    uvr_exe = shutil.which("uvr.py")
+    if not uvr_exe or not Path(uvr_exe).exists():
+        raise FileNotFoundError(
+            "uvr.py not found. Install Ultimate Vocal Remover or set the path "
+            "to the uvr.py script."
+        )
+
     cmd = [
         "python",
-        "uvr.py",
+        uvr_exe,
         "--input",
         str(input_path),
         "--output",

--- a/models/separation_manager.py
+++ b/models/separation_manager.py
@@ -35,12 +35,18 @@ def separate_and_score(input_path: str) -> Tuple[Path, Path, float]:
     uvr_dir = tempdir / "uvr"
     demucs_dir = tempdir / "demucs"
 
-    vocal_uvr, inst_uvr = run_uvr(input_path, str(uvr_dir))
+    try:
+        vocal_uvr, inst_uvr = run_uvr(input_path, str(uvr_dir))
+    except FileNotFoundError:
+        vocal_uvr, inst_uvr = None, None
     vocal_demucs, inst_demucs = run_demucs(input_path, str(demucs_dir))
 
-    score = compare_stems(inst_uvr, inst_demucs)
+    if inst_uvr is not None:
+        score = compare_stems(inst_uvr, inst_demucs)
+    else:
+        score = 0.0
 
-    if score >= 0.5:
+    if score >= 0.5 and vocal_uvr is not None and inst_uvr is not None:
         vocal, inst = vocal_uvr, inst_uvr
     else:
         vocal, inst = vocal_demucs, inst_demucs


### PR DESCRIPTION
## Summary
- check for `uvr.py` and raise a clear error when it is missing
- fall back to Demucs-only separation if UVR isn't installed
- document optional UVR dependency in README

## Testing
- `python -m py_compile chords.py lyrics.py models/*.py ultimate_chord_reader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f70737108321b91b34a46476fe5d