### PR TITLE
Add local Demucs invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ The `ultimate_chord_reader.py` script provides a local workflow for transcribing
 ### Optional: Ultimate Vocal Remover
 By default the separation step uses both [Demucs](https://github.com/facebookresearch/demucs) and Ultimate Vocal Remover (UVR). If `uvr.py` is not available on your system, the script will automatically fall back to using Demucs only. To enable UVR support, clone the UVR repository and ensure the `uvr.py` entry point is on your `PATH`.
 
+### Demucs Usage
+The project invokes Demucs through the local Python environment. Install it with:
+
+```bash
+pip install demucs
+```
+
+If Demucs is missing, the separation step will log a warning and continue with
+UVR only. You may also run Demucs manually and place the resulting stems next to
+your input files.
+

--- a/models/demucs_loader.py
+++ b/models/demucs_loader.py
@@ -1,11 +1,19 @@
 """Demucs loader for Ultimate Chord Reader.
-Uses the Demucs Python API to perform source separation. Falls back to the
-CLI if the API is unavailable.
+
+The module prefers the Demucs Python API and only falls back to a subprocess
+call.  The subprocess invocation uses ``python -m demucs.separate`` so that a
+local virtual environment is honored.
+
+If Demucs is not installed, :func:`run_demucs` raises ``FileNotFoundError`` with
+instructions for installing the package or running separation manually.
 """
 
 from __future__ import annotations
 
+import sys
+import shutil
 import subprocess
+from subprocess import CalledProcessError
 from pathlib import Path
 from typing import Tuple
 
@@ -24,21 +32,28 @@ def run_demucs(input_path: str, output_dir: str) -> Tuple[Path, Path]:
     output = Path(output_dir)
     output.mkdir(parents=True, exist_ok=True)
 
-    if apply_model is None or torch is None:
-        # Fallback to CLI invocation
-        cmd = ["demucs", str(input_path), "--out", str(output)]
-        subprocess.run(cmd, check=True)
-        demucs_out = output / Path(input_path).stem
+    demucs_out = output / Path(input_path).stem
+
+    if apply_model is not None and torch is not None:
+        try:
+            model = get_model("htdemucs")
+            wav = model.audio_loader.load_audio(input_path)[0]
+            wav = torch.from_numpy(wav)
+            sources = apply_model(model, wav[None])
+            demucs_out.mkdir(parents=True, exist_ok=True)
+            for name, src in zip(model.sources, sources[0]):
+                dest = demucs_out / f"{name}.wav"
+                model.audio_loader.save_audio(dest, src)
+        except Exception as exc:
+            raise RuntimeError("Demucs API failed to run") from exc
     else:
-        model = get_model("htdemucs")
-        wav = model.audio_loader.load_audio(input_path)[0]
-        wav = torch.from_numpy(wav)
-        sources = apply_model(model, wav[None])
-        demucs_out = output / Path(input_path).stem
-        demucs_out.mkdir(parents=True, exist_ok=True)
-        for name, src in zip(model.sources, sources[0]):
-            dest = demucs_out / f"{name}.wav"
-            model.audio_loader.save_audio(dest, src)
+        cmd = [sys.executable, "-m", "demucs.separate", str(input_path), "--out", str(output)]
+        try:
+            subprocess.run(cmd, check=True)
+        except (FileNotFoundError, CalledProcessError) as exc:
+            raise FileNotFoundError(
+                "Demucs is not installed. Install it with 'pip install demucs' or run separation manually."
+            ) from exc
 
     vocal_path = demucs_out / "vocals.wav"
     instrumental_path = demucs_out / "no_vocals.wav"


### PR DESCRIPTION
## Summary
- handle Demucs through Python API or `python -m demucs.separate`
- skip Demucs gracefully when unavailable
- update README with Demucs installation instructions

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685106f30f1c8321a01a2c4f87a43724