### PR TITLE
Use Demucs python API

### DIFF
--- a/models/demucs_loader.py
+++ b/models/demucs_loader.py
@@ -1,63 +1,61 @@
 """Demucs loader for Ultimate Chord Reader.
 
-The module prefers the Demucs Python API and only falls back to invoking the
-``demucs`` command-line tool found on ``PATH``.  This avoids relying on a
-system-wide installation and keeps execution within the current virtual
-environment.
+This module uses the Demucs Python API exclusively to perform source
+separation.  No subprocess invocation of the ``demucs`` CLI is attempted.
 
-If Demucs is not installed, :func:`run_demucs` raises ``FileNotFoundError`` with
-instructions for installing the package or running separation manually.
+If the required ``demucs`` or ``torch`` modules are missing, :func:`run_demucs`
+raises ``FileNotFoundError`` with instructions for installing the package.
 """
 
 from __future__ import annotations
 
-import sys
-import shutil
-import subprocess
-from subprocess import CalledProcessError
 from pathlib import Path
 from typing import Tuple
 
-try:
+try:  # pragma: no cover - optional dependency
     from demucs.apply import apply_model
     from demucs.pretrained import get_model
+    from demucs.audio import AudioFile, save_audio
     import torch
 except Exception:  # pragma: no cover - optional dependency
     apply_model = None  # type: ignore
     get_model = None  # type: ignore
+    AudioFile = None  # type: ignore
+    save_audio = None  # type: ignore
     torch = None  # type: ignore
 
 
 def run_demucs(input_path: str, output_dir: str) -> Tuple[Path, Path]:
     """Run Demucs and return paths to vocal and instrumental stems."""
+    if apply_model is None or get_model is None or AudioFile is None or save_audio is None or torch is None:
+        raise FileNotFoundError(
+            "Demucs or torch not installed. Install them with 'pip install demucs torch'."
+        )
+
+    print("Using Demucs Python API for separation.")
+
     output = Path(output_dir)
     output.mkdir(parents=True, exist_ok=True)
 
     demucs_out = output / Path(input_path).stem
 
-    if apply_model is not None and torch is not None:
-        try:
-            model = get_model("htdemucs")
-            wav = model.audio_loader.load_audio(input_path)[0]
-            wav = torch.from_numpy(wav)
-            sources = apply_model(model, wav[None])
-            demucs_out.mkdir(parents=True, exist_ok=True)
-            for name, src in zip(model.sources, sources[0]):
-                dest = demucs_out / f"{name}.wav"
-                model.audio_loader.save_audio(dest, src)
-        except Exception as exc:
-            raise RuntimeError("Demucs API failed to run") from exc
-    else:
-        exe = shutil.which("demucs")
-        if exe is None:
-            raise FileNotFoundError(
-                "Demucs executable not found. Install it with 'pip install demucs' in your virtual environment."
-            )
-        cmd = [exe, "separate", str(input_path), "--out", str(output)]
-        try:
-            subprocess.run(cmd, check=True)
-        except CalledProcessError as exc:
-            raise RuntimeError("Demucs CLI failed") from exc
+    try:
+        model = get_model("htdemucs")
+        wav = AudioFile(input_path).read(
+            streams=0,
+            samplerate=model.samplerate,
+            channels=model.audio_channels,
+        )
+        ref = wav.mean(0)
+        wav = (wav - ref.mean()) / ref.std()
+        sources = apply_model(model, wav[None], split=True, overlap=0.25, progress=False)[0]
+        sources = sources * ref.std() + ref.mean()
+        demucs_out.mkdir(parents=True, exist_ok=True)
+        for source, name in zip(sources, model.sources):
+            dest = demucs_out / f"{name}.wav"
+            save_audio(source, dest, model.samplerate)
+    except Exception as exc:
+        raise RuntimeError("Demucs API failed to run") from exc
 
     vocal_path = demucs_out / "vocals.wav"
     instrumental_path = demucs_out / "no_vocals.wav"

--- a/models/separation_manager.py
+++ b/models/separation_manager.py
@@ -1,7 +1,8 @@
 """Stem separation manager for Ultimate Chord Reader.
 
-Both Demucs and UVR are attempted if available. If Demucs is missing, the
-process continues with UVR only and logs a warning.
+Both Demucs and UVR are attempted if available. Demucs is invoked via its
+Python API. If Demucs is missing, the process continues with UVR only and logs
+a warning.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- refactor `run_demucs` to use Demucs Python API exclusively
- update docs and messaging

## Testing
- `python -m py_compile ultimate_chord_reader.py chords.py lyrics.py models/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511185f0188321b95bfa31caf8a7e4