### PR TITLE
Fix demucs setup and skip non-audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-The script no longer installs packages automatically at runtime. Ensure all
-dependencies are available before launching the tool.
+The script will attempt to install any missing Python packages when you run it.
+You can still pre-install everything manually with `pip install -r requirements.txt`.
 
 ### Optional: Ultimate Vocal Remover
 By default the separation step uses both [Demucs](https://github.com/facebookresearch/demucs) and Ultimate Vocal Remover (UVR). If `uvr.py` is not available on your system, the script will automatically fall back to using Demucs only. To enable UVR support, clone the UVR repository and ensure the `uvr.py` entry point is on your `PATH`.


### PR DESCRIPTION
## Summary
- auto-install missing Python dependencies on first run
- skip placeholder files in `input_songs`
- update README about automatic dependency installation

## Testing
- `python - <<'EOF'
from pathlib import Path
INPUT_DIR=Path('input_songs')
for file in INPUT_DIR.iterdir():
    if not file.is_file():
        continue
    if file.suffix.lower() not in {'.mp3','.wav','.flac','.m4a','.ogg'}:
        continue
    print('Will process', file)
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_68520cd4ed2483219b6bfc38a80e7654