### PR TITLE
Install openai-whisper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 pytest
 torch
-whisper
+openai-whisper
 librosa
 numpy
 soundfile

--- a/ultimate_chord_reader.py
+++ b/ultimate_chord_reader.py
@@ -12,14 +12,24 @@ from typing import List, Tuple
 # attempting implicit installation.  This keeps the runtime predictable and
 # avoids long network operations when a package is missing.
 
-REQUIRED = [ "torch", "whisper", "librosa", "numpy", "soundfile", "demucs", "dora-search", "treetable", "imageio-ffmpeg",]
+REQUIRED = {
+    "torch": "torch",
+    "whisper": "openai-whisper",
+    "librosa": "librosa",
+    "numpy": "numpy",
+    "soundfile": "soundfile",
+    "demucs": "demucs",
+    "dora": "dora-search",
+    "treetable": "treetable",
+    "imageio_ffmpeg": "imageio-ffmpeg",
+}
 
 missing: list[str] = []
-for _pkg in REQUIRED:
+for import_name, pip_name in REQUIRED.items():
     try:
-        __import__(_pkg)
+        __import__(import_name)
     except Exception:  # pragma: no cover - import failure path
-        missing.append(_pkg)
+        missing.append(pip_name)
 
 def ensure_dependencies() -> None:
     """Install any missing dependencies using pip."""


### PR DESCRIPTION
## Summary
- update requirements to use the correct Whisper package
- map pip package names to import names so dependency guard installs openai-whisper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852346627b08321aea9199572b8fb55