### PR TITLE
Fix whisper dependency crash

### DIFF
--- a/lyrics.py
+++ b/lyrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-import whisper
+import whisper  # provided by the *openai-whisper* package (pip install openai-whisper)
 
 
 def transcribe(vocal_path: str) -> List[Tuple[float, float, str, float]]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ soundfile
 demucs==4.0.1
 dora-search>=0.1.12
 treetable==0.2.5
-imageio-ffmpeg>=0.4.9
 openai-whisper>=20231101
+imageio-ffmpeg>=0.4.9
+# imageio-ffmpeg bundles ffprobe so Demucs Python API works

--- a/ultimate_chord_reader.py
+++ b/ultimate_chord_reader.py
@@ -12,7 +12,17 @@ from typing import List, Tuple
 # attempting implicit installation.  This keeps the runtime predictable and
 # avoids long network operations when a package is missing.
 
-REQUIRED = [ "torch", "whisper", "librosa", "numpy", "soundfile", "demucs", "dora-search", "treetable", "imageio-ffmpeg",]
+REQUIRED = [
+    "torch",
+    "librosa",
+    "numpy",
+    "soundfile",
+    "demucs",
+    "dora-search",
+    "treetable",
+    "imageio-ffmpeg",
+    "openai-whisper",
+]
 
 missing: list[str] = []
 for _pkg in REQUIRED:


### PR DESCRIPTION
## Summary
- update `REQUIRED` packages to use `openai-whisper`
- clarify `whisper` import note in `lyrics.py`
- document `openai-whisper` and `imageio-ffmpeg` pins in `requirements.txt`

## Testing
- `pytest -q`
- `python -m py_compile ultimate_chord_reader.py lyrics.py chords.py`


------
https://chatgpt.com/codex/tasks/task_e_68524ae3c05c8321848a033def7f4eb2