### PR TITLE
Add lightweight tests with stubs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Instructions for Ultimate Chord Reader
+
+This repository depends on heavy packages that are not available in Codex environments.
+To keep verification lightweight, agents should **not** run the full application or
+install large dependencies. Instead, use the included lightweight tests.
+
+## Testing
+
+1. Run a syntax check:
+   ```bash
+   python -m py_compile ultimate_chord_reader.py models/*.py chords.py lyrics.py
+   ```
+2. Run the minimal test suite:
+   ```bash
+   pytest -q tests/test_basic.py
+   ```
+
+These tests rely on stub modules under `tests/stubs` and avoid heavy
+runtime requirements. Do **not** attempt to run other parts of the program.

--- a/tests/stubs/imageio_ffmpeg.py
+++ b/tests/stubs/imageio_ffmpeg.py
@@ -1,0 +1,7 @@
+# minimal stub for testing
+
+def get_ffmpeg_exe():
+    return None
+
+def get_ffprobe_exe():
+    return None

--- a/tests/stubs/numpy.py
+++ b/tests/stubs/numpy.py
@@ -1,0 +1,5 @@
+class ndarray:
+    def __init__(self, value=0):
+        self.value = value
+    def squeeze(self):
+        return self.value

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,41 @@
+import sys
+import importlib.util
+from pathlib import Path
+
+# Add stub modules to sys.path so imports in production code succeed
+sys.path.insert(0, str(Path(__file__).resolve().parent / 'stubs'))
+
+# Load ultimate_chord_reader as a module from its file
+ucr_path = Path(__file__).resolve().parents[1] / 'ultimate_chord_reader.py'
+spec = importlib.util.spec_from_file_location('ucr', ucr_path)
+ucr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ucr)
+
+
+def test_format_chart_basic(tmp_path):
+    lyrics = [
+        (0.0, 1.0, 'hello', 0.9),
+        (2.0, 3.0, 'world', 0.9),
+    ]
+    chords = [
+        ('C', 0.0, 0.9),
+        ('G', 2.0, 0.9),
+    ]
+    text = ucr.format_chart(
+        title='Test',
+        bpm=60.0,
+        key='C',
+        time_sig='4/4',
+        lyrics=lyrics,
+        chords=chords,
+        confidence=80.0,
+    )
+    lines = text.splitlines()
+    assert lines[-1] == 'C G\thello world'
+
+
+def test_overwrite_and_remove(tmp_path):
+    f = tmp_path / 'sample.txt'
+    f.write_text('data')
+    ucr.overwrite_and_remove(f)
+    assert not f.exists()


### PR DESCRIPTION
## Summary
- add instructions for agents to run a minimal test routine
- create pytest-based lightweight tests
- include stub modules for heavy dependencies

## Testing
- `python -m py_compile ultimate_chord_reader.py models/*.py chords.py lyrics.py`
- `pytest -q tests/test_basic.py`


------
https://chatgpt.com/codex/tasks/task_e_68539604d3c08321bb01ff5994e295fd