### PR TITLE
Improve chart formatting and BPM handling

### DIFF
--- a/chords.py
+++ b/chords.py
@@ -53,6 +53,11 @@ def analyze_instrumental(
     """Analyze BPM, key, and chords from an instrumental stem."""
     y, sr = librosa.load(inst_path, sr=sr)
     tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    # fold extremes into a sensible 60-160 bpm range
+    while tempo > 160:
+        tempo /= 2.0
+    while tempo < 60:
+        tempo *= 2.0
 
     chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
     key = librosa.feature.chroma_stft(y=y, sr=sr).mean(axis=1)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -34,6 +34,29 @@ def test_format_chart_basic(tmp_path):
     assert lines[-1] == 'C G\thello world'
 
 
+def test_carryover_hidden(tmp_path):
+    lyrics = [
+        (0.0, 1.0, 'foo', 0.9),
+        (5.0, 6.0, 'bar', 0.9),
+    ]
+    chords = [
+        ('C', 0.0, 0.9),
+    ]
+    text = ucr.format_chart(
+        title='Test',
+        bpm=60.0,
+        key='C',
+        time_sig='4/4',
+        lyrics=lyrics,
+        chords=chords,
+        confidence=80.0,
+    )
+    lines = text.splitlines()
+    # last two bars: first shows chord, second hides carry over
+    assert lines[-2] == 'C\tfoo'
+    assert lines[-1] == '\tbar'
+
+
 def test_overwrite_and_remove(tmp_path):
     f = tmp_path / 'sample.txt'
     f.write_text('data')


### PR DESCRIPTION
## Summary
- hide carry-over chords that don't change within a bar
- add small lyric-grouping grace window
- calculate lyric transcription confidence from Whisper results
- fold extreme BPM estimates into a 60-160 range
- test for carry-over chord suppression

## Testing
- `python -m py_compile ultimate_chord_reader.py models/*.py chords.py lyrics.py`
- `pytest -q tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_68539ff0bb388321a74bb3ebbef56458