### PR TITLE
Improve BPM detection using drums

### DIFF
--- a/bpm_drums.py
+++ b/bpm_drums.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple, List
+import tempfile
+import subprocess
+import sys
+import numpy as np
+
+from ultimate_chord_reader import overwrite_and_remove
+
+
+def _separate_drums(src: str, work_dir: str) -> Path:
+    """Run Demucs to extract the drum stem and return its path."""
+    out = Path(work_dir)
+    cmd = [
+        sys.executable,
+        "-m",
+        "demucs.separate",
+        "-n",
+        "htdemucs_6s",
+        "-o",
+        str(out),
+        src,
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    drum = next(out.rglob("drums.wav"), None)
+    if drum is None:
+        raise RuntimeError("Drum stem not found")
+    return drum
+
+
+def get_bpm_from_drums(src: str) -> Tuple[float, List[float]]:
+    """Return (bpm, beat_times) from *src* using a drum stem."""
+    from madmom.features.beats import RNNBeatProcessor, DBNBeatTrackingProcessor
+
+    with tempfile.TemporaryDirectory() as td:
+        drum_path = _separate_drums(src, td)
+        proc = RNNBeatProcessor()(str(drum_path))
+        beats = DBNBeatTrackingProcessor(fps=100)(proc)
+        beat_times = beats.tolist()
+        overwrite_and_remove(drum_path)
+
+    if len(beat_times) < 2:
+        raise RuntimeError("Insufficient beats")
+
+    diffs = np.diff(beat_times)
+    bpm = 60.0 / float(np.median(diffs))
+    while bpm > 160:
+        bpm /= 2.0
+    while bpm < 60:
+        bpm *= 2.0
+    return bpm, beat_times
+

--- a/models/separation_manager.py
+++ b/models/separation_manager.py
@@ -43,7 +43,7 @@ def separate_and_score(input_path: str, work_dir: str) -> Tuple[Path, Path, floa
     demucs_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        vocal_demucs, inst_demucs = run_demucs(input_path, str(demucs_dir))
+        vocal_demucs, inst_demucs = run_demucs(input_path, str(demucs_dir), model="htdemucs_6s")
     except (FileNotFoundError, RuntimeError) as exc:
         print(f"[Demucs] unavailable → {exc}")
         vocal_demucs = inst_demucs = None

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,6 +21,7 @@ def test_format_chart_basic(tmp_path):
         ('C', 0.0, 0.9),
         ('G', 2.0, 0.9),
     ]
+    beat_times = [0, 1, 2, 3, 4]
     text = ucr.format_chart(
         title='Test',
         bpm=60.0,
@@ -28,6 +29,7 @@ def test_format_chart_basic(tmp_path):
         time_sig='4/4',
         lyrics=lyrics,
         chords=chords,
+        beat_times=beat_times,
         confidence=80.0,
     )
     lines = text.splitlines()
@@ -42,6 +44,7 @@ def test_carryover_hidden(tmp_path):
     chords = [
         ('C', 0.0, 0.9),
     ]
+    beat_times = list(range(0, 9))
     text = ucr.format_chart(
         title='Test',
         bpm=60.0,
@@ -49,6 +52,7 @@ def test_carryover_hidden(tmp_path):
         time_sig='4/4',
         lyrics=lyrics,
         chords=chords,
+        beat_times=beat_times,
         confidence=80.0,
     )
     lines = text.splitlines()


### PR DESCRIPTION
## Summary
- use Demucs 6‑stem model for separation
- add a drum BPM analyzer using madmom
- surface beat times from `analyze_instrumental`
- derive bar ranges from beat vector and reduce chord clutter
- update lightweight tests for new API

## Testing
- `python -m py_compile ultimate_chord_reader.py models/*.py chords.py lyrics.py bpm_drums.py`
- `pytest -q tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_6853aaa4cd78832183e8aa63ab555a73